### PR TITLE
Added support for trap_function pragma

### DIFF
--- a/make/nashorn/pom.xml
+++ b/make/nashorn/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+This code is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License version 2 only, as
+published by the Free Software Foundation.  Oracle designates this
+particular file as subject to the "Classpath" exception as provided
+by Oracle in the LICENSE file that accompanied this code.
+
+This code is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+version 2 for more details (a copy is included in the LICENSE file that
+accompanied this code).
+
+You should have received a copy of the GNU General Public License version
+2 along with this work; if not, write to the Free Software Foundation,
+Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+or visit www.oracle.com if you need additional information or have any
+questions.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.openjdk.nashorn</groupId>
+  <artifactId>nashorn-core</artifactId>
+  <name>OpenJDK Nashorn</name>
+  <version>15.4_trap_functions</version>
+  <packaging>jar</packaging>
+  <description>Nashorn is an Open Source JavaScript (ECMAScript 5.1 and some 6 features) engine for the JVM.</description>
+  <url>https://github.com/openjdk/nashorn</url>
+
+  <licenses>
+    <license>
+      <name>GPL v2 with the Classpath exception</name>
+      <url>https://github.com/openjdk/nashorn/blob/main/LICENSE</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Attila Szegedi</name>
+      <email>szegedia@gmail.com</email>
+      <url>http://github.com/szegedi</url>
+    </developer>
+  </developers>
+
+
+  <scm>
+    <connection>scm:git:git://github.com/openjdk/nashorn.git</connection>
+    <developerConnection>scm:git:ssh://github.com:openjdk/nashorn.git</developerConnection>
+    <url>http://github.com/openjdk/nashorn/tree/main</url>
+  </scm>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>7.3.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+      <version>7.3.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-tree</artifactId>
+      <version>7.3.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-util</artifactId>
+      <version>7.3.1</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/visitor/FunctionTrapVisitor.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/visitor/FunctionTrapVisitor.java
@@ -1,0 +1,82 @@
+package org.openjdk.nashorn.internal.ir.visitor;
+
+import org.openjdk.nashorn.internal.ir.*;
+
+import java.util.Collections;
+
+/**
+ * Injects custom code block (function) into several different parsed JS AST nodes.
+ *
+ * <p/>
+ */
+public class FunctionTrapVisitor extends SimpleNodeVisitor {
+    private final String trapName;
+
+    public FunctionTrapVisitor(String trapName) {
+        this.trapName = trapName;
+    }
+
+    @Override
+    public Node leaveWhileNode(WhileNode node) {
+        if (hasInterrupt(node.getBody())) {
+            return node;
+        }
+        return node.setBody(
+                this.getLexicalContext(),
+                injectFun(node.getToken(), node.getFinish(), node.getLineNumber(), node.getBody())
+        );
+    }
+
+    @Override
+    public Node leaveForNode(ForNode node) {
+        if (hasInterrupt(node.getBody())) {
+            return node;
+        }
+        return node.setBody(
+                this.getLexicalContext(),
+                injectFun(node.getToken(), node.getFinish(), node.getLineNumber(), node.getBody())
+        );
+    }
+
+    @Override
+    public Node leaveFunctionNode(FunctionNode node) {
+        if (hasInterrupt(node.getBody())) {
+            return node;
+        }
+
+        if (node.getBody().getStatements().isEmpty()) {
+            return node;
+        }
+
+        if (node.getName().equals(trapName)) {
+            return node;
+        }
+
+        return node.setBody(
+                this.getLexicalContext(),
+                injectFun(node.getToken(), node.getFinish(), node.getLineNumber(), node.getBody())
+        );
+    }
+
+    private boolean hasInterrupt(Block block) {
+        return block.getStatements().stream()
+                .filter(s -> !s.toString().contains("trap_function"))
+                .anyMatch(s -> s.toString().contains(trapName));
+    }
+
+    private Block injectFun(long token, int finish, int lineNumber, Block innerBody) {
+        IdentNode identNode = new IdentNode(token, finish, trapName);
+
+        return new Block(
+                token,
+                finish,
+                new ExpressionStatement(
+                        lineNumber,
+                        token,
+                        finish,
+                        new CallNode(lineNumber, token, finish, identNode, Collections.emptyList(), false)
+                ),
+                new BlockStatement(innerBody)
+        );
+    }
+}

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/visitor/FunctionTrapVisitor.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/visitor/FunctionTrapVisitor.java
@@ -3,6 +3,7 @@ package org.openjdk.nashorn.internal.ir.visitor;
 import org.openjdk.nashorn.internal.ir.*;
 
 import java.util.Collections;
+import java.util.regex.Pattern;
 
 /**
  * Injects custom code block (function) into several different parsed JS AST nodes.
@@ -10,6 +11,12 @@ import java.util.Collections;
  * <p/>
  */
 public class FunctionTrapVisitor extends SimpleNodeVisitor {
+
+    // Captures pragma such as 'trap_function my_function';
+    public static final Pattern TRAP_FUNCTION_PRAGMA_PATTERN = Pattern.compile(
+            "(\"|')trap_function\\s([A-Za-z_\\-0-9]+)(\"|');"
+    );
+    public static String TRAP_PRAGMA = "trap_function";
     private final String trapName;
 
     public FunctionTrapVisitor(String trapName) {
@@ -60,7 +67,7 @@ public class FunctionTrapVisitor extends SimpleNodeVisitor {
 
     private boolean hasInterrupt(Block block) {
         return block.getStatements().stream()
-                .filter(s -> !s.toString().contains("trap_function"))
+                .filter(s -> !s.toString().contains(TRAP_PRAGMA))
                 .anyMatch(s -> s.toString().contains(trapName));
     }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/visitor/TrapFunctionVisitor.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/visitor/TrapFunctionVisitor.java
@@ -19,7 +19,7 @@ public class TrapFunctionVisitor extends SimpleNodeVisitor {
 
     @Override
     public Node leaveWhileNode(WhileNode node) {
-        if (hasInterrupt(node.getBody())) {
+        if (hasTrap(node.getBody())) {
             return node;
         }
         return node.setBody(
@@ -30,7 +30,7 @@ public class TrapFunctionVisitor extends SimpleNodeVisitor {
 
     @Override
     public Node leaveForNode(ForNode node) {
-        if (hasInterrupt(node.getBody())) {
+        if (hasTrap(node.getBody())) {
             return node;
         }
         return node.setBody(
@@ -41,7 +41,7 @@ public class TrapFunctionVisitor extends SimpleNodeVisitor {
 
     @Override
     public Node leaveFunctionNode(FunctionNode node) {
-        if (hasInterrupt(node.getBody())) {
+        if (hasTrap(node.getBody())) {
             return node;
         }
 
@@ -59,7 +59,7 @@ public class TrapFunctionVisitor extends SimpleNodeVisitor {
         );
     }
 
-    private boolean hasInterrupt(Block block) {
+    private boolean hasTrap(Block block) {
         return block.getStatements().stream()
                 .filter(s -> !ScriptUtils.containsTrapPragma(s.toString()))
                 .anyMatch(s -> s.toString().contains(trapName));

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/visitor/TrapFunctionVisitor.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/visitor/TrapFunctionVisitor.java
@@ -1,25 +1,19 @@
 package org.openjdk.nashorn.internal.ir.visitor;
 
+import org.openjdk.nashorn.api.scripting.ScriptUtils;
 import org.openjdk.nashorn.internal.ir.*;
 
 import java.util.Collections;
-import java.util.regex.Pattern;
 
 /**
- * Injects custom code block (function) into several different parsed JS AST nodes.
+ * Visits JS AST and injects configured `trap function` into loops and function calls.
  *
  * <p/>
  */
-public class FunctionTrapVisitor extends SimpleNodeVisitor {
-
-    // Captures pragma such as 'trap_function my_function';
-    public static final Pattern TRAP_FUNCTION_PRAGMA_PATTERN = Pattern.compile(
-            "(\"|')trap_function\\s([A-Za-z_\\-0-9]+)(\"|');"
-    );
-    public static String TRAP_PRAGMA = "trap_function";
+public class TrapFunctionVisitor extends SimpleNodeVisitor {
     private final String trapName;
 
-    public FunctionTrapVisitor(String trapName) {
+    public TrapFunctionVisitor(String trapName) {
         this.trapName = trapName;
     }
 
@@ -67,7 +61,7 @@ public class FunctionTrapVisitor extends SimpleNodeVisitor {
 
     private boolean hasInterrupt(Block block) {
         return block.getStatements().stream()
-                .filter(s -> !s.toString().contains(TRAP_PRAGMA))
+                .filter(s -> !ScriptUtils.containsTrapPragma(s.toString()))
                 .anyMatch(s -> s.toString().contains(trapName));
     }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Parser.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Parser.java
@@ -25,133 +25,28 @@
 
 package org.openjdk.nashorn.internal.parser;
 
-import static org.openjdk.nashorn.internal.codegen.CompilerConstants.ANON_FUNCTION_PREFIX;
-import static org.openjdk.nashorn.internal.codegen.CompilerConstants.EVAL;
-import static org.openjdk.nashorn.internal.codegen.CompilerConstants.PROGRAM;
-import static org.openjdk.nashorn.internal.parser.TokenType.ARROW;
-import static org.openjdk.nashorn.internal.parser.TokenType.ASSIGN;
-import static org.openjdk.nashorn.internal.parser.TokenType.CASE;
-import static org.openjdk.nashorn.internal.parser.TokenType.CATCH;
-import static org.openjdk.nashorn.internal.parser.TokenType.CLASS;
-import static org.openjdk.nashorn.internal.parser.TokenType.COLON;
-import static org.openjdk.nashorn.internal.parser.TokenType.COMMARIGHT;
-import static org.openjdk.nashorn.internal.parser.TokenType.COMMENT;
-import static org.openjdk.nashorn.internal.parser.TokenType.CONST;
-import static org.openjdk.nashorn.internal.parser.TokenType.DECPOSTFIX;
-import static org.openjdk.nashorn.internal.parser.TokenType.DECPREFIX;
-import static org.openjdk.nashorn.internal.parser.TokenType.ELLIPSIS;
-import static org.openjdk.nashorn.internal.parser.TokenType.ELSE;
-import static org.openjdk.nashorn.internal.parser.TokenType.EOF;
-import static org.openjdk.nashorn.internal.parser.TokenType.EOL;
-import static org.openjdk.nashorn.internal.parser.TokenType.EQ_STRICT;
-import static org.openjdk.nashorn.internal.parser.TokenType.ESCSTRING;
-import static org.openjdk.nashorn.internal.parser.TokenType.EXPORT;
-import static org.openjdk.nashorn.internal.parser.TokenType.EXTENDS;
-import static org.openjdk.nashorn.internal.parser.TokenType.FINALLY;
-import static org.openjdk.nashorn.internal.parser.TokenType.FUNCTION;
-import static org.openjdk.nashorn.internal.parser.TokenType.IDENT;
-import static org.openjdk.nashorn.internal.parser.TokenType.IF;
-import static org.openjdk.nashorn.internal.parser.TokenType.IMPORT;
-import static org.openjdk.nashorn.internal.parser.TokenType.INCPOSTFIX;
-import static org.openjdk.nashorn.internal.parser.TokenType.LBRACE;
-import static org.openjdk.nashorn.internal.parser.TokenType.LBRACKET;
-import static org.openjdk.nashorn.internal.parser.TokenType.LET;
-import static org.openjdk.nashorn.internal.parser.TokenType.LPAREN;
-import static org.openjdk.nashorn.internal.parser.TokenType.MUL;
-import static org.openjdk.nashorn.internal.parser.TokenType.PERIOD;
-import static org.openjdk.nashorn.internal.parser.TokenType.RBRACE;
-import static org.openjdk.nashorn.internal.parser.TokenType.RBRACKET;
-import static org.openjdk.nashorn.internal.parser.TokenType.RPAREN;
-import static org.openjdk.nashorn.internal.parser.TokenType.SEMICOLON;
-import static org.openjdk.nashorn.internal.parser.TokenType.SPREAD_ARRAY;
-import static org.openjdk.nashorn.internal.parser.TokenType.STATIC;
-import static org.openjdk.nashorn.internal.parser.TokenType.STRING;
-import static org.openjdk.nashorn.internal.parser.TokenType.SUPER;
-import static org.openjdk.nashorn.internal.parser.TokenType.TEMPLATE;
-import static org.openjdk.nashorn.internal.parser.TokenType.TEMPLATE_HEAD;
-import static org.openjdk.nashorn.internal.parser.TokenType.TEMPLATE_MIDDLE;
-import static org.openjdk.nashorn.internal.parser.TokenType.TEMPLATE_TAIL;
-import static org.openjdk.nashorn.internal.parser.TokenType.TERNARY;
-import static org.openjdk.nashorn.internal.parser.TokenType.VAR;
-import static org.openjdk.nashorn.internal.parser.TokenType.VOID;
-import static org.openjdk.nashorn.internal.parser.TokenType.WHILE;
-import static org.openjdk.nashorn.internal.parser.TokenType.YIELD;
-import static org.openjdk.nashorn.internal.parser.TokenType.YIELD_STAR;
-
-import java.io.Serializable;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.function.Consumer;
 import org.openjdk.nashorn.internal.codegen.CompilerConstants;
 import org.openjdk.nashorn.internal.codegen.Namespace;
-import org.openjdk.nashorn.internal.ir.AccessNode;
-import org.openjdk.nashorn.internal.ir.BaseNode;
-import org.openjdk.nashorn.internal.ir.BinaryNode;
-import org.openjdk.nashorn.internal.ir.Block;
-import org.openjdk.nashorn.internal.ir.BlockStatement;
-import org.openjdk.nashorn.internal.ir.BreakNode;
-import org.openjdk.nashorn.internal.ir.CallNode;
-import org.openjdk.nashorn.internal.ir.CaseNode;
-import org.openjdk.nashorn.internal.ir.CatchNode;
-import org.openjdk.nashorn.internal.ir.ClassNode;
-import org.openjdk.nashorn.internal.ir.ContinueNode;
-import org.openjdk.nashorn.internal.ir.DebuggerNode;
-import org.openjdk.nashorn.internal.ir.EmptyNode;
-import org.openjdk.nashorn.internal.ir.ErrorNode;
-import org.openjdk.nashorn.internal.ir.Expression;
-import org.openjdk.nashorn.internal.ir.ExpressionList;
-import org.openjdk.nashorn.internal.ir.ExpressionStatement;
-import org.openjdk.nashorn.internal.ir.ForNode;
-import org.openjdk.nashorn.internal.ir.FunctionNode;
-import org.openjdk.nashorn.internal.ir.IdentNode;
-import org.openjdk.nashorn.internal.ir.IfNode;
-import org.openjdk.nashorn.internal.ir.IndexNode;
-import org.openjdk.nashorn.internal.ir.JoinPredecessorExpression;
-import org.openjdk.nashorn.internal.ir.LabelNode;
-import org.openjdk.nashorn.internal.ir.LexicalContext;
-import org.openjdk.nashorn.internal.ir.LiteralNode;
 import org.openjdk.nashorn.internal.ir.Module;
-import org.openjdk.nashorn.internal.ir.Node;
-import org.openjdk.nashorn.internal.ir.ObjectNode;
-import org.openjdk.nashorn.internal.ir.PropertyKey;
-import org.openjdk.nashorn.internal.ir.PropertyNode;
-import org.openjdk.nashorn.internal.ir.ReturnNode;
-import org.openjdk.nashorn.internal.ir.RuntimeNode;
-import org.openjdk.nashorn.internal.ir.Statement;
-import org.openjdk.nashorn.internal.ir.SwitchNode;
-import org.openjdk.nashorn.internal.ir.TemplateLiteral;
-import org.openjdk.nashorn.internal.ir.TernaryNode;
-import org.openjdk.nashorn.internal.ir.ThrowNode;
-import org.openjdk.nashorn.internal.ir.TryNode;
-import org.openjdk.nashorn.internal.ir.UnaryNode;
-import org.openjdk.nashorn.internal.ir.VarNode;
-import org.openjdk.nashorn.internal.ir.WhileNode;
-import org.openjdk.nashorn.internal.ir.WithNode;
+import org.openjdk.nashorn.internal.ir.*;
 import org.openjdk.nashorn.internal.ir.debug.ASTWriter;
 import org.openjdk.nashorn.internal.ir.debug.PrintVisitor;
+import org.openjdk.nashorn.internal.ir.visitor.FunctionTrapVisitor;
 import org.openjdk.nashorn.internal.ir.visitor.NodeVisitor;
-import org.openjdk.nashorn.internal.runtime.Context;
-import org.openjdk.nashorn.internal.runtime.ErrorManager;
-import org.openjdk.nashorn.internal.runtime.JSErrorType;
-import org.openjdk.nashorn.internal.runtime.ParserException;
-import org.openjdk.nashorn.internal.runtime.RecompilableScriptFunctionData;
-import org.openjdk.nashorn.internal.runtime.ScriptEnvironment;
-import org.openjdk.nashorn.internal.runtime.ScriptFunctionData;
-import org.openjdk.nashorn.internal.runtime.ScriptingFunctions;
-import org.openjdk.nashorn.internal.runtime.Source;
-import org.openjdk.nashorn.internal.runtime.Timing;
+import org.openjdk.nashorn.internal.runtime.*;
 import org.openjdk.nashorn.internal.runtime.linker.NameCodec;
 import org.openjdk.nashorn.internal.runtime.logging.DebugLogger;
 import org.openjdk.nashorn.internal.runtime.logging.Loggable;
 import org.openjdk.nashorn.internal.runtime.logging.Logger;
+
+import java.io.Serializable;
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.openjdk.nashorn.internal.codegen.CompilerConstants.*;
+import static org.openjdk.nashorn.internal.parser.TokenType.*;
 
 /**
  * Builds the IR.
@@ -163,6 +58,7 @@ public class Parser extends AbstractParser implements Loggable {
     private static final String GET_NAME = "get";
     private static final String SET_NAME = "set";
 
+    private static final Pattern TRAP_FUNCTION_PATTERN = Pattern.compile("(\"|')trap_function=([A-Za-z]+)(\"|');");
     /** Current env. */
     private final ScriptEnvironment env;
 
@@ -181,6 +77,9 @@ public class Parser extends AbstractParser implements Loggable {
 
     /** to receive line information from Lexer when scanning multine literals. */
     protected final Lexer.LineInfoReceiver lineInfoReceiver;
+
+    private final boolean injectTrapFunctionCalls;
+    private final String trapName;
 
     private RecompilableScriptFunctionData reparsedFunction;
 
@@ -220,6 +119,19 @@ public class Parser extends AbstractParser implements Loggable {
      */
     public Parser(final ScriptEnvironment env, final Source source, final ErrorManager errors, final boolean strict, final int lineOffset, final DebugLogger log) {
         super(source, errors, strict, lineOffset);
+
+        // Disable/enable trap injection
+        Matcher matcher = TRAP_FUNCTION_PATTERN.matcher(new String(source.getContent()));
+
+        if (matcher.find() && matcher.groupCount() == 3) {
+             this.injectTrapFunctionCalls = true;
+             this.trapName = matcher.group(2);
+             log.info("Function trap injection enabled, trap_function=" + trapName);
+        } else {
+             this.injectTrapFunctionCalls = false;
+             this.trapName = null;
+        }
+
         this.lc = new ParserContext();
         this.defaultNames = new ArrayDeque<>();
         this.env = env;
@@ -319,7 +231,12 @@ public class Parser extends AbstractParser implements Loggable {
 
             scanFirstToken();
             // Begin parse.
-            return program(scriptName, reparseFlags);
+            FunctionNode functionNode = program(scriptName, reparseFlags);
+
+            if (injectTrapFunctionCalls) {
+                return  (FunctionNode) functionNode.accept(new FunctionTrapVisitor(trapName));
+            }
+            return functionNode;
         } catch (final Exception e) {
             handleParseException(e);
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Parser.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Parser.java
@@ -57,8 +57,6 @@ public class Parser extends AbstractParser implements Loggable {
     private static final String CONSTRUCTOR_NAME = "constructor";
     private static final String GET_NAME = "get";
     private static final String SET_NAME = "set";
-
-    private static final Pattern TRAP_FUNCTION_PATTERN = Pattern.compile("(\"|')trap_function=([A-Za-z]+)(\"|');");
     /** Current env. */
     private final ScriptEnvironment env;
 
@@ -121,12 +119,12 @@ public class Parser extends AbstractParser implements Loggable {
         super(source, errors, strict, lineOffset);
 
         // Disable/enable trap injection
-        Matcher matcher = TRAP_FUNCTION_PATTERN.matcher(new String(source.getContent()));
+        Matcher matcher = FunctionTrapVisitor.TRAP_FUNCTION_PRAGMA_PATTERN.matcher(new String(source.getContent()));
 
         if (matcher.find() && matcher.groupCount() == 3) {
              this.injectTrapFunctionCalls = true;
              this.trapName = matcher.group(2);
-             log.info("Function trap injection enabled, trap_function=" + trapName);
+             log.info("Detected trap_function pragma, function=" + trapName);
         } else {
              this.injectTrapFunctionCalls = false;
              this.trapName = null;

--- a/test/nashorn/script/basic/javaexceptions.js.EXPECTED
+++ b/test/nashorn/script/basic/javaexceptions.js.EXPECTED
@@ -2,6 +2,6 @@ true
 true
 java.net.MalformedURLException: no protocol: invalid_url
 true
-java.lang.IllegalMonitorStateException: current thread is not owner
+java.lang.IllegalMonitorStateException
 true
 java.io.IOException: I/O failed


### PR DESCRIPTION
This PR extends the `Nashorn` parser to support `trap_function` pragma.

Trap function pragma has following syntax:

```js
'trap_function trapFunctionName';
```

In case pragma is provided in the source, `Nashorn` will inject trap function named `trapFunctionName()` into all function calls and loops.

Example:

```js
'trap_function trapFunctionName';

var myFunction = function() {
   console.log('Hello World');
}
```

Will be parsed as:

```js
var myFunction = function() {
   trapFunctionName();
   console.log('Hello World');
}
```


Loop Example:

```js
'trap_function trapFunctionName';

var x = 'test';

while (true) {
    x += ' test';
}
```

Will be parsed as:

```js
'trap_function trapFunctionName';

var x = 'test';

while (true) {
    trapFunctionName();
    x += ' test';
}
```